### PR TITLE
Implement Dockerfile with ffmpeg installation

### DIFF
--- a/Task4/Dockerfile
+++ b/Task4/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y ffmpeg
+
+ENTRYPOINT ["ffmpeg"]


### PR DESCRIPTION
This pull request adds a Dockerfile that builds an Ubuntu-based image and installs ffmpeg. The container is configured to run ffmpeg as the entrypoint.

Closes #6